### PR TITLE
Fixed code cardinality

### DIFF
--- a/packages/shr-fhir-export/lib/export.js
+++ b/packages/shr-fhir-export/lib/export.js
@@ -3189,9 +3189,11 @@ class FHIRExporter {
       if (typeof code.system !== 'undefined' && code.system !== null) {
         const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
         systemEl.fixedUri = systemDf.fixedUri = code.system;
+        systemEl.min = 1;
       }
       const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
       codeEl.fixedCode = codeDf.fixedCode = code.code;
+      codeEl.min = 1;
 
     } return;
     }

--- a/packages/shr-fhir-export/lib/export.js
+++ b/packages/shr-fhir-export/lib/export.js
@@ -3189,10 +3189,18 @@ class FHIRExporter {
       if (typeof code.system !== 'undefined' && code.system !== null) {
         const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
         systemEl.fixedUri = systemDf.fixedUri = code.system;
+        if(systemEl.min != 1) {
+          systemDf.min = 1;
+          systemDf.max = systemEl.max;
+        }
         systemEl.min = 1;
       }
       const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
       codeEl.fixedCode = codeDf.fixedCode = code.code;
+      if(codeEl.min != 1) {
+        codeDf.min = 1;
+        codeDf.max = codeEl.max;
+      }
       codeEl.min = 1;
 
     } return;


### PR DESCRIPTION
This pull request addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-16

For testing, the mCODE spec provides a useful example: in the `ECOGPerformanceStatus` profile, the `code` element has updated cardinality.

I made this change as part of the FHIR export, since that's where the logic pertaining to fixed codes already existed. However, if it would be more useful for this change to exist as part of the expand logic, I could try to move it to there.