### PR TITLE
Fixing incorrect error message

### DIFF
--- a/packages/shr-fhir-export/lib/export.js
+++ b/packages/shr-fhir-export/lib/export.js
@@ -3536,7 +3536,7 @@ class FHIRExporter {
     // Iterate the rules one at a time
     for (const cpr of cp.rules) {
 
-      if (cpr.primaryProfile || cpr.noProfiles) {
+      if (cpr.primaryProfile || cpr.noProfile) {
         continue;
       }
 

--- a/packages/shr-text-import/errorMessages.txt
+++ b/packages/shr-text-import/errorMessages.txt
@@ -28,6 +28,7 @@ Number, Message, Solution, deduplicationKeys
 01027, 'Done preprocessing namespace',,
 01028, 'Start importing value set namespace',,
 01029, 'Done importing value set namespace',,
+01030, 'Namespace level content profile flag(s) for namespace ${namespace} only apply to Entries or Groups.',,
 11001, 'Element name "${name}" should begin with a capital letter', 'Rename the specified Element', 'errorNumber'
 11002, 'Entry name '${name}' should begin with a capital letter' , 'Rename the specified Entry', 'errorNumber'
 11003, 'Unable to resolve value set reference: ${valueSet}', 'Invalid value set reference double check the name and the path', 'errorNumber'

--- a/packages/shr-text-import/lib/contentProfileListener.js
+++ b/packages/shr-text-import/lib/contentProfileListener.js
@@ -86,6 +86,7 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
   enterNamespaceFlag(ctx) {
     const noProfile = (ctx.KW_NO_PROFILE() != null);
     const primaryProfile = (ctx.KW_ALL_PRIMARY() != null);
+    let warnAbstractOrElement = false;
     for (const de of this._specs.dataElements.byNamespace(this._currentNs)) {
       if (de.isEntry || de.isGroup) {
         this._currentDef = new ContentProfile(de.identifier);
@@ -96,7 +97,13 @@ class ContentProfileImporter extends SHRContentProfileParserListener {
         this._currentRule.primaryProfile = primaryProfile;
         this._currentDef.addRule(this._currentRule);
         this._specs.contentProfiles.add(this._currentDef);
+      } else {
+        warnAbstractOrElement = true;
       }
+    }
+    if (warnAbstractOrElement) {
+      // 01030, 'Namespace level content profile flag(s) for namespace ${namespace} only apply to Entries or Groups.',,
+      logger.warn({ namespace: this._currentNs } ,'01030');
     }
   }
 


### PR DESCRIPTION
This fixes a bug that was raised here: https://chat.fhir.org/#narrow/stream/197290-cimpl/topic/Conflicting.20definitions. An error message like the following was being output incorrectly: 
```
ERROR 13064: 'Could not find FHIR element for content profile rule with path '
During: FHIR Export
Class: MedicationDispense
Target Class: DomainResource
```
This was happening because in `export.js`, there was a typo, and `noProfile` rules were allowed through a block of code where they didn't belong. This did not functionally do anything, because this code deals with Must Support not No Profile, but it causes the error. This error had to do with NPing things which are `Abstract`, or which inherit their mapping from an `Abstract`. Therefore a warning was also added to warn users when they apply a NP flag to a namespace, that the flag will not NP `Abstracts`.

To test this PR, you can build mCODE using this branch and compare to master to confirm that this does not change the functionality. To see the error, change the mCODE content profile, `ig-mcode-cp.txt` so that all of `obf` is given the `NP` flag, and delete the individual assignments of the `NP` flag to elements in `obf`. So:
```
...
Namespace: obf NP // Make this change!
  // Nothing down here anymore
Namespace: vital
...
```
When you build this new spec using master, you should see the error `13064` described above. When you build this spec using this branch, you should see a warning `01030` warning that namespace level flags only apply to `Entries` or `Groups` inside `obf`. However, the actual output should be exactly the same, which can be verified using `diff -r out1/ out2`.