### PR TITLE
Changes for global install of SHR-CLI

### DIFF
--- a/packages/shr-cli/app.js
+++ b/packages/shr-cli/app.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs-extra');
 const path = require('path');
 const mkdirp = require('mkdirp');

--- a/packages/shr-cli/package.json
+++ b/packages/shr-cli/package.json
@@ -9,6 +9,9 @@
     "url": "git@github.com:standardhealth/shr-cli.git"
   },
   "main": "app.js",
+  "bin": {
+    "cimpl": "app.js"
+  },
   "scripts": {
     "ig:publish": "java -Xms4g -Xmx8g -jar ./out/fhir/guide/org.hl7.fhir.publisher.jar -ig ./out/fhir/guide/ig.json",
     "ig:open": "opener ./out/fhir/guide/output/index.html",


### PR DESCRIPTION
Adds small changes that allow `shr-cli` to be installed as a global package from NPM (once it is published).

I tested this locally by running `npm install -g ./` from within `packages/shr-cli`. Once you do that, you should be able to run `cimpl -c myconfig.json path/to/spec` from any directory.

The Jira said we want to have it run using `cimpl` but that can easily be changed if that's not the case anymore.