### PR TITLE
Use effective identifier to find content profile rules

### DIFF
--- a/packages/shr-data-dict-export/lib/export.js
+++ b/packages/shr-data-dict-export/lib/export.js
@@ -335,7 +335,7 @@ function fillElementLines(dataElementLines, profileLines, vsMap, de, specs, conf
 
     let includesTypeConstraints = f.constraintsFilter.includesType.constraints;
     let codeConstraints = f.constraintsFilter.code.constraints;
-    const cpRules = (specs.contentProfiles.findRulesByIdentifierAndField(de.identifier, f.identifier));
+    const cpRules = (specs.contentProfiles.findRulesByIdentifierAndField(de.identifier, f.effectiveIdentifier));
 
     for (const rule of cpRules) {
       if (!rule.mustSupport) continue; // not a must-support rule


### PR DESCRIPTION
Elements that were substituted will have a different identifier and effectiveIdentifier.
The name in the content profile will correspond to the effectiveIdentifier's name.
The result of this change is that substituted elements listed in content profiles
are now correctly appearing in the data dictionary.

This pull request addresses https://standardhealthrecord.atlassian.net/browse/MCODE-92.

As an additional note: although the description for this issue only refers to missing value sets, this change also fixes the related issue with missing data elements. In the case of mCODE specifically:
- the value set `CancerStagingSystemVS` is now shown in the Value Sets and Value Set Details tabs.
- the data elements named `Cancer Staging System`, which appear on several different profiles, are now shown in the Data Elements tab.