### PR TITLE
Rename SHR-CLI binary to 'shr-cli'

### DIFF
--- a/packages/shr-cli/package.json
+++ b/packages/shr-cli/package.json
@@ -10,7 +10,7 @@
   },
   "main": "app.js",
   "bin": {
-    "cimpl": "app.js"
+    "shr-cli": "app.js"
   },
   "scripts": {
     "ig:publish": "java -Xms4g -Xmx8g -jar ./out/fhir/guide/org.hl7.fhir.publisher.jar -ig ./out/fhir/guide/ig.json",


### PR DESCRIPTION
Changed the `bin` key to 'shr-cli'. This still isn't published to NPM since we don't have the shr-cli NPM repo.

To test this locally, run `npm install -g ./` from within `packages/shr-cli`. Once you do that, you should be able to run `shr-cli -c myconfig.json path/to/spec` from any directory.