### PR TITLE
Report error when element added without Property keyword

### DIFF
--- a/packages/shr-expand/errorMessages.txt
+++ b/packages/shr-expand/errorMessages.txt
@@ -50,4 +50,5 @@ Number, Message, Solution, deduplicationKeys
 12048, 'Invalid constraint path: ${target1}',  'Unknown', 'errorNumber'
 12049, 'Cannot determine target item of mapping for ${identifier1}',  'Unknown', 'errorNumber'
 12050, 'Invalid format for ${type} with value ${value}', 'Unknown', 'errorNumber'
+12051, 'New property ${propertyName} added on ${elementName} without Property keyword', 'Please use Property keyword when introducing new properties.', 'errorNumber'
 

--- a/packages/shr-expand/lib/expand.js
+++ b/packages/shr-expand/lib/expand.js
@@ -312,7 +312,15 @@ class Expander {
 
     if (element.basedOn.length == 0) {
       if (element.value) setCurrentElementAsOriginalModifier(element.value);
-      if (element.fields) element.fields.forEach(f => setCurrentElementAsOriginalModifier(f));
+      if (element.fields) {
+        element.fields.forEach(f => {
+          if (f.mustInherit) {
+            // 12051, 'New property ${propertyName} added on ${elementName} without Property keyword', 'Please use Property keyword when introducing new properties.', 'errorNumber'
+            logger.error({propertyName: f.identifier.name, elementName: element.identifier.name}, '12051');
+          }
+          setCurrentElementAsOriginalModifier(f);
+        });
+      }
 
     } else {
       for (const baseID of element.basedOn) {
@@ -436,6 +444,10 @@ class Expander {
             manageValueInheritance(baseField, ef);
             manageCardHistory(baseField, ef);
           } else {
+            if (ef.mustInherit) {
+              // 12051, 'New property ${propertyName} added on ${elementName} without Property keyword', 'Please use Property keyword when introducing new properties.', 'errorNumber'
+              logger.error({propertyName: ef.identifier.name, elementName: element.identifier.name}, '12051');
+            }
             setCurrentElementAsOriginalModifier(ef);
           }
         }

--- a/packages/shr-models/lib/models.js
+++ b/packages/shr-models/lib/models.js
@@ -1655,6 +1655,11 @@ class Value {
     this._inheritedFrom = inheritedFrom;
   }
 
+  get mustInherit() { return this._mustInherit; }
+  set mustInherit(mustInherit) {
+    this._mustInherit = mustInherit;
+  }
+
   withInheritedFrom(inheritedFrom) {
     this.inheritedFrom = inheritedFrom;
     return this;
@@ -1678,6 +1683,9 @@ class Value {
     }
     if (this._inheritedFrom) {
       clone._inheritedFrom = this._inheritedFrom;
+    }
+    if (this._mustInherit) {
+      clone._mustInherit = this._mustInherit;
     }
     if (this._constraintHistory) {
       clone._constraintHistory = this._constraintHistory.clone();

--- a/packages/shr-text-import/lib/dataElementListener.js
+++ b/packages/shr-text-import/lib/dataElementListener.js
@@ -450,7 +450,7 @@ class DataElementImporter extends SHRDataElementParserListener {
       const field = this.processCountAndTypes(ctx.propertyField().count(), [ctx.propertyField().propertyFieldType()]);
       if (this._currentDef.fields.some(f => f.identifier && f.identifier.equals(field.identifier))) {
         // 11040, 'Property "${name}" already exists.', 'Remove or rename redundant property', 'errorNumber'
-        logger.error({ name: field.identifier.name }, 'name');
+        logger.error({ name: field.identifier.name }, 'name', '11040');
       }
       else {
         this.addFieldToCurrentDef(field);
@@ -508,6 +508,7 @@ class DataElementImporter extends SHRDataElementParserListener {
             logger.error('11042');
           }
           else {
+            field.mustInherit = true;
             this.addFieldToCurrentDef(field);
           }
         }


### PR DESCRIPTION
New properties must use the Property keyword when they are
added. It is permissible to not use the Property keyword
when constraining a property that has already been declared,
either on the current element or an ancestor of the element.

As an example, this error helps in detecting cases where an
author intended to constrain an inherited property, but did
not spell the name of the property correctly.

Additionally, an error logged when a property is redundantly
declared now logs correctly.

This PR addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-18. The extra fix related to error message 11040 is included because the code path that results in that error is closely related to code paths related to the new error being reported.

To experience this error, create a data element definition including an `Entry` that constrains a newly-defined property without first declaring it by using the `Property` keyword.