### PR TITLE
Showing output of shr-cli in Travis

### DIFF
--- a/test-scripts/shr-cli.sh
+++ b/test-scripts/shr-cli.sh
@@ -7,6 +7,7 @@ if [ ! -z "$SHR_CLI" ]; then
     git clone https://github.com/standardhealth/shr-spec.git
     git -C ./shr-spec checkout dev6
     node . shr-spec/spec > run.log
+    cat run.log
     ERRORS=$(grep "errors" run.log | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g')
     if [[ "$ERRORS" != "0 errors" ]]; then 
         ( echo There were errors in running shr-cli)


### PR DESCRIPTION
This makes it so that when Travis runs on `shr-cli`, you can see the output of `shr-cli` from Travis. You can test that this is working by looking at the Travis build for this branch, you should be able to see all the output from the run by looking at the `shr-cli` job.