### PR TITLE
Update text on IG Code Systems page

### DIFF
--- a/packages/shr-fhir-export/lib/ig.js
+++ b/packages/shr-fhir-export/lib/ig.js
@@ -1006,21 +1006,24 @@ ${match[1]}
   const codeSystemsHtmlPath = path.join(outDir, 'pages', 'codesystems.html');
   if (htmlCodeSystems.length > 0) {
     const codeSystemsHtml = fs.readFileSync(codeSystemsHtmlPath, 'utf8');
-    const codeSystemsDisclaimer = `<p>The code systems listed below are defined by this IG and:</p>
+    const codeSystemsDisclaimer = `<p>The code systems listed below are defined by this IG and are used by the
+    local value sets, logical models, and profiles shown on their respective pages in this IG.</p>
     <ol>
-      <li>are used by ${hideSupporting ? 'primary ' : ''}local value sets defined in this IG; or</li>
-      <li>contain individual codes used directly in the ${hideSupporting ? 'primary ' : ''}logical models and profiles in this IG.</li>
+      <li>are used by local value sets defined in this IG; or</li>
+      <li>contain individual codes used directly in the logical models and profiles in this IG.</li>
     </ol>
     <p>This list is not inclusive of code systems associated with external value sets used in the IG.</p>`;
     let updatedCodeSystemsHtml = codeSystemsHtml.replace('<code-systems-go-here/>', htmlCodeSystems.join(''))
       .replace('<code-systems-disclaimer/>', codeSystemsDisclaimer);
-    if (hideSupporting) {
-      updatedCodeSystemsHtml = updatedCodeSystemsHtml
-        .replace('<code-systems-header/>', '<h2>Primary code systems used in this Implementation Guide</h2>');
-    } else {
-      updatedCodeSystemsHtml = updatedCodeSystemsHtml
-        .replace('<code-systems-header/>', '<h2>Code systems used in this Implementation Guide</h2>');
-    }
+    updatedCodeSystemsHtml = updatedCodeSystemsHtml
+      .replace('<code-systems-header/>', '<h2>Code systems defined by and used in this Implementation Guide</h2>');
+    // if (hideSupporting) {
+    //   updatedCodeSystemsHtml = updatedCodeSystemsHtml
+    //     .replace('<code-systems-header/>', '<h2>Primary code systems defined by and used in this Implementation Guide</h2>');
+    // } else {
+    //   updatedCodeSystemsHtml = updatedCodeSystemsHtml
+    //     .replace('<code-systems-header/>', '<h2>Code systems defined by and used in this Implementation Guide</h2>');
+    // }
 
     fs.writeFileSync(codeSystemsHtmlPath, updatedCodeSystemsHtml, 'utf8');
   } else {

--- a/packages/shr-fhir-export/lib/ig.js
+++ b/packages/shr-fhir-export/lib/ig.js
@@ -1004,28 +1004,28 @@ ${match[1]}
 
   // Rewrite the updated CodeSystems HTML file
   const codeSystemsHtmlPath = path.join(outDir, 'pages', 'codesystems.html');
-  const codeSystemsHtml = fs.readFileSync(codeSystemsHtmlPath, 'utf8');
-  const codeSystemsDisclaimer = `<p>The code systems listed below include:</p>
-  <ol>
-    <li>code systems used in the definition of value sets in this IG; and</li>
-    <li>code systems for individual codes used directly in the logical models and profiles.</li>
-  </ol>
-  <p>This list is not inclusive of code systems associated with external value sets used in the IG.</p>`;
-  let updatedCodeSystemsHtml = codeSystemsHtml.replace('<code-systems-go-here/>', htmlCodeSystems.join(''))
-    .replace('<code-systems-disclaimer/>', codeSystemsDisclaimer);
-  if (hideSupporting) {
-    updatedCodeSystemsHtml = updatedCodeSystemsHtml
-      .replace('<code-systems-header/>', '<h2>Primary code systems used in this Implementation Guide</h2>');
-  } else {
-    updatedCodeSystemsHtml = updatedCodeSystemsHtml
-      .replace('<code-systems-header/>', '<h2>Code systems used in this Implementation Guide</h2>');
-  }
-  if (htmlCodeSystems.length === 0) {
-    updatedCodeSystemsHtml = updatedCodeSystemsHtml
-      .replace('<table class="codes">', 'None\n<table class="codes" style="display: none">');
-  }
+  if (htmlCodeSystems.length > 0) {
+    const codeSystemsHtml = fs.readFileSync(codeSystemsHtmlPath, 'utf8');
+    const codeSystemsDisclaimer = `<p>The code systems listed below are defined by this IG and:</p>
+    <ol>
+      <li>are used by ${hideSupporting ? 'primary ' : ''}local value sets defined in this IG; or</li>
+      <li>contain individual codes used directly in the ${hideSupporting ? 'primary ' : ''}logical models and profiles in this IG.</li>
+    </ol>
+    <p>This list is not inclusive of code systems associated with external value sets used in the IG.</p>`;
+    let updatedCodeSystemsHtml = codeSystemsHtml.replace('<code-systems-go-here/>', htmlCodeSystems.join(''))
+      .replace('<code-systems-disclaimer/>', codeSystemsDisclaimer);
+    if (hideSupporting) {
+      updatedCodeSystemsHtml = updatedCodeSystemsHtml
+        .replace('<code-systems-header/>', '<h2>Primary code systems used in this Implementation Guide</h2>');
+    } else {
+      updatedCodeSystemsHtml = updatedCodeSystemsHtml
+        .replace('<code-systems-header/>', '<h2>Code systems used in this Implementation Guide</h2>');
+    }
 
-  fs.writeFileSync(codeSystemsHtmlPath, updatedCodeSystemsHtml, 'utf8');
+    fs.writeFileSync(codeSystemsHtmlPath, updatedCodeSystemsHtml, 'utf8');
+  } else {
+    fs.unlinkSync(codeSystemsHtmlPath);
+  }
 
   // Rewrite the updated Models HTML file
   const modelsHtmlPath = path.join(outDir, 'pages', 'logical.html');
@@ -1083,9 +1083,9 @@ ${match[1]}
     const graphItem = '<li><a href="graph.html">Graph Viewer</a></li>';
     navbarHtml = navbarHtml.replace(graphItem, '<!-- no graph viewer -->');
   }
-  if (target === 'FHIR_DSTU_2') {
+  if (target === 'FHIR_DSTU_2' || htmlCodeSystems.length === 0) {
     const modelsItem = '<li><a href="codesystems.html">Code Systems</a></li>';
-    navbarHtml = navbarHtml.replace(modelsItem, '<!-- no code systems (DSTU2) -->');
+    navbarHtml = navbarHtml.replace(modelsItem, '<!-- no code systems -->');
   }
   if (htmlSearchParameters.length === 0) {
     const searchParametersItem = '<li><a href="searchparameters.html">Search Parameters</a></li>';

--- a/packages/shr-fhir-export/lib/ig.js
+++ b/packages/shr-fhir-export/lib/ig.js
@@ -1006,24 +1006,13 @@ ${match[1]}
   const codeSystemsHtmlPath = path.join(outDir, 'pages', 'codesystems.html');
   if (htmlCodeSystems.length > 0) {
     const codeSystemsHtml = fs.readFileSync(codeSystemsHtmlPath, 'utf8');
-    const codeSystemsDisclaimer = `<p>The code systems listed below are defined by this IG and are used by the
+    const codeSystemsDisclaimer = `<p>The code systems listed below are used by the
     local value sets, logical models, and profiles shown on their respective pages in this IG.</p>
-    <ol>
-      <li>are used by local value sets defined in this IG; or</li>
-      <li>contain individual codes used directly in the logical models and profiles in this IG.</li>
-    </ol>
     <p>This list is not inclusive of code systems associated with external value sets used in the IG.</p>`;
     let updatedCodeSystemsHtml = codeSystemsHtml.replace('<code-systems-go-here/>', htmlCodeSystems.join(''))
       .replace('<code-systems-disclaimer/>', codeSystemsDisclaimer);
     updatedCodeSystemsHtml = updatedCodeSystemsHtml
-      .replace('<code-systems-header/>', '<h2>Code systems defined by and used in this Implementation Guide</h2>');
-    // if (hideSupporting) {
-    //   updatedCodeSystemsHtml = updatedCodeSystemsHtml
-    //     .replace('<code-systems-header/>', '<h2>Primary code systems defined by and used in this Implementation Guide</h2>');
-    // } else {
-    //   updatedCodeSystemsHtml = updatedCodeSystemsHtml
-    //     .replace('<code-systems-header/>', '<h2>Code systems defined by and used in this Implementation Guide</h2>');
-    // }
+      .replace('<code-systems-header/>', '<h2>Code systems used in this Implementation Guide</h2>');
 
     fs.writeFileSync(codeSystemsHtmlPath, updatedCodeSystemsHtml, 'utf8');
   } else {


### PR DESCRIPTION
In order to make the Code Systems page easier to understand, the text on the page is revised. The header text is consistent regardless of the IG configuration's `hideSupporting` value. In addition, if there would be no code systems shown on that page, the page is not included in the published IG, and the link to the Code Systems page is removed. 

To test the paths within this change, export and publish IGs where:
- No code systems are present. mCODE works well for this.
- Code systems are present.

This change addresses [CIMPL-85](https://standardhealthrecord.atlassian.net/browse/CIMPL-85).