### PR TITLE
Fix filtering issues

### DIFF
--- a/packages/shr-cli/app.js
+++ b/packages/shr-cli/app.js
@@ -162,9 +162,10 @@ if (expSpecifications.contentProfiles.all.length > 0) {
   filter = true;
 }
 
+let filterReasons = new Set();
 if (filter) {
   const specificationsFilter = new SpecificationsFilter(specifications, expSpecifications, configSpecifications);
-  [specifications, expSpecifications] = specificationsFilter.filter();
+  [specifications, expSpecifications, filterReasons] = specificationsFilter.filter();
 }
 
 const failedExports = [];
@@ -185,7 +186,7 @@ if (doDD) {
 
 if (doFHIR) {
   try {
-    const fhirResults = shrFE.exportToFHIR(expSpecifications, configSpecifications);
+    const fhirResults = shrFE.exportToFHIR(expSpecifications, filterReasons, configSpecifications);
     const baseFHIRPath = path.join(program.out, 'fhir');
     const baseFHIRProfilesPath = path.join(baseFHIRPath, 'profiles');
     mkdirp.sync(baseFHIRProfilesPath);

--- a/packages/shr-cli/app.js
+++ b/packages/shr-cli/app.js
@@ -162,7 +162,7 @@ if (expSpecifications.contentProfiles.all.length > 0) {
   filter = true;
 }
 
-let filterReasons = new Set();
+let filterReasons;
 if (filter) {
   const specificationsFilter = new SpecificationsFilter(specifications, expSpecifications, configSpecifications);
   [specifications, expSpecifications, filterReasons] = specificationsFilter.filter();

--- a/packages/shr-fhir-export/lib/export.js
+++ b/packages/shr-fhir-export/lib/export.js
@@ -93,7 +93,7 @@ class FHIRExporter {
     // Iterate through the elements and do the mappings
     for (const element of this._specs.dataElements.all) {
       // If the only reason this element hasn't been filtered is that it is a parent, we don't want a profile
-      const reason = this._filterReasons.get(element.identifier).reason;
+      const reason = this._filterReasons ? this._filterReasons.get(element.identifier).reason : null;
       if (reason && reason.size === 1 && reason.has('parent')) {
         continue;
       }


### PR DESCRIPTION
Remove profiles that only exist because they are parents, and remove extensions that aren't used by profiles.

This addresses https://standardhealthrecord.atlassian.net/browse/CIMPL-80

In order to verify that this fixes the bug, run the CLI using the `ig-mcode/ig-mcode-r4-config.json` configuration file against the latest `master` of the spec. Do this using `master` of the toolchain first, and then using this branch.

The output directory when running with `master` should include a profile called `obf-ActionRequest.json` and an extension called `obf-ReferenceRange-extension.json`. When running with this branch, those files (as well as several others) should be gone.

Please review this work carefully; I'm a bit worried that I might have accidentally trimmed more profiles than I should have in this process, since a lot were removed. It's probably best for @cmoesel to review this, though anyone else can take a look as well.